### PR TITLE
Updated prop ID to accept a Number

### DIFF
--- a/components/InputCheckbox.vue
+++ b/components/InputCheckbox.vue
@@ -30,7 +30,7 @@ export default {
   },
   props: {
     id: {
-      type: String,
+      type: [ String, Number ],
       default: () => `ck_${String(Math.random().toString(36).substr(2, 9))}`,
     },
     value: {


### PR DESCRIPTION
…use we tend to use unique IDs. This could be bypassed by converting the number to a string before hand, so it's up for debate.